### PR TITLE
Adding NCSU domain for SnapClass

### DIFF
--- a/cors.lua
+++ b/cors.lua
@@ -62,6 +62,9 @@ domain_allowed['arena.csc.ncsu.edu'] = true
 domain_allowed['snapapps.fi.ncsu.edu'] = true
 -- CONTACT Saminur Islam <sislam8@ncsu.edu>,, Tiffany Barnes <tmbarnes@ncsu.edu>,, Veronica Catete <vmcatete@ncsu.edu>, Ally Limke <anlimke@ncsu.edu>
 domain_allowed['lin-class17.csc.ncsu.edu'] = true
+-- CONTACT Taylor Yang <tyang27@ncsu.edu>
+domain_allowed['sd-vm27.csc.ncsu.edu'] = true
+domain_allowed['sd-vm39.csc.ncsu.edu'] = true
 
 -- CONTACT: Ken Khan
 domain_allowed['ecraft2learn.github.io'] = true


### PR DESCRIPTION
We're developing new features for NCSU SnapClass and are hosting it on separate servers to test and run. The server domains have been added to cors.lua to be whitelisted.

We should only need access until April 23, 2025.